### PR TITLE
docs: Update READMEs with all 7 tools and correct API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,12 @@ Ask your AI assistant to search across your indexed repositories:
 | Tool | Description |
 |------|-------------|
 | `search` | Search code using Zoekt query syntax (regex, file filters, language filters) |
+| `search_symbols` | Find symbol definitions (functions, classes, methods) with optional kind filtering |
+| `search_files` | Search for files by filename pattern |
+| `find_references` | Find all definitions and usages of a symbol across repositories |
 | `list_repos` | List all indexed repositories with optional filtering |
 | `file_content` | Retrieve full file contents from indexed repositories |
+| `get_health` | Check health status of MCP server and Zoekt backend |
 
 ## Documentation
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,7 +59,7 @@ Initial indexing may take 10-60 minutes depending on the number and size of repo
 ### 6. Verify
 
 ```bash
-curl "http://localhost:6070/search?q=type:repo&format=json" | jq '.Result.RepoURLs | keys'
+curl -s -X POST -d '{"Q":"type:repo"}' http://localhost:6070/api/search | jq '.Result.Files[].Repository' | sort -u
 ```
 
 ## Configuration Reference
@@ -136,7 +136,7 @@ zoekt-indexserver:
 docker-compose logs zoekt-indexserver | tail -50
 
 # Count indexed repositories
-curl "http://localhost:6070/search?q=type:repo&format=json" | jq '.Result.RepoURLs | length'
+curl -s -X POST -d '{"Q":"type:repo"}' http://localhost:6070/api/search | jq '[.Result.Files[].Repository] | unique | length'
 ```
 
 ### Force Re-index
@@ -190,7 +190,7 @@ Your GitHub token may be expired or have insufficient permissions.
 1. Wait for initial indexing to complete (check logs)
 2. Verify repos are indexed:
    ```bash
-   curl "http://localhost:6070/search?q=type:repo&format=json"
+   curl -s -X POST -d '{"Q":"type:repo"}' http://localhost:6070/api/search | jq '.Result.Files[].Repository'
    ```
 
 ### Container keeps restarting


### PR DESCRIPTION
## Summary

Updates documentation to reflect the new tools added in the previous PR.

## Changes

### Main README
- Updated MCP Tools table to include all 7 tools:
  - `search`
  - `search_symbols` (NEW)
  - `search_files` (NEW)
  - `find_references` (NEW)
  - `list_repos`
  - `file_content`
  - `get_health` (NEW)

### Docker README
- Updated curl examples to use POST `/api/search` endpoint
- The old `format=json` query parameter approach is no longer supported by the Zoekt client